### PR TITLE
Fix usage instructions for Go 1.16

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ I know the project doesn't follow the standard Golang structure. It's on the tod
 ```bash
 git clone git@github.com:ktzar/scummatlas.git
 cd scummatlas
+export GO111MODULE="auto"
 export GOPATH=`pwd`
 go run src/scummatlas/main/scummatlas.go -gamedir=/path/to/games/monkey2 -outputdir out
 ```


### PR DESCRIPTION
The usage instructions in the README file didn’t work for me. I got this error:
```
src/scummatlas/main/scummatlas.go:4:2: package fileutils is not in GOROOT (/usr/lib/go/src/fileutils)
src/scummatlas/main/scummatlas.go:11:2: package scummatlas is not in GOROOT (/usr/lib/go/src/scummatlas)
src/scummatlas/main/scummatlas.go:12:2: package scummatlas/condlog is not in GOROOT (/usr/lib/go/src/scummatlas/condlog)
src/scummatlas/main/scummatlas.go:13:2: package scummatlas/templates is not in GOROOT (/usr/lib/go/src/scummatlas/templates)
```

This pull request prevents this error by fixing the usage instructions.

The problem was that I was using Go 1.16, but this version changes the default value of the environment variable GO111MODULE to "on" but we need "auto" (or "off") to build scummatlas.

See also https://go.dev/blog/go116-module-changes.

Note that according to that blog post, scummatlas will stop working with Go 1.17.